### PR TITLE
Both Python-Sirius and Python2 library building is now available

### DIFF
--- a/src/library/PRUserial485/__init__.py
+++ b/src/library/PRUserial485/__init__.py
@@ -1,21 +1,24 @@
 import os as _os
 import inspect as _inspect
 import subprocess as _sp
-
+import sys
 from .implementation import *
 
+PYTHON3 = "3"
 
-def _get_last_commit_hash():
-    """Get commit Hash of the repository of the calling file."""
-    fname = _os.path.realpath(_inspect.stack()[1][1])
-    path = fname.rpartition(_os.path.sep)[0]
-    pwd = _os.path.abspath('.')
-    return _sp.getoutput('cd ' + path +
-                         '; git log --format=%h -1; cd ' + pwd)
+if(sys.version[0] == PYTHON3):
+  # Needed only for Python3
+  def _get_last_commit_hash():
+      """Get commit Hash of the repository of the calling file."""
+      fname = _os.path.realpath(_inspect.stack()[1][1])
+      path = fname.rpartition(_os.path.sep)[0]
+      pwd = _os.path.abspath('.')
+      return _sp.getoutput('cd ' + path +
+                           '; git log --format=%h -1; cd ' + pwd)
 
 
-with open(_os.path.join(__path__[0], 'VERSION'), 'r') as _f:
-     __version__ = _f.read().strip() + ':' + _get_last_commit_hash()
+  with open(_os.path.join(__path__[0], 'VERSION'), 'r') as _f:
+       __version__ = _f.read().strip() + ':' + _get_last_commit_hash()
 
 
-del implementation  # clean package namespace
+  del implementation  # clean package namespace

--- a/src/library_build.sh
+++ b/src/library_build.sh
@@ -35,9 +35,11 @@ echo ".."
 echo "..."
 echo "Building and installing Python library..."
 if [ -z "$1" ]; then
-  ./setup.py install
+  python-sirius setup.py install
+  python2 setup.py install
 else
-  ./setup.py $1
+  python-sirius setup.py $1
+  python2 setup.py $1
 fi
 echo "OK"
 


### PR DESCRIPTION
Old library was only builded for python-sirius (python 3.6.1).