### PR TITLE
Fix OFFSET_SHRAM_READ reference in comments

### DIFF
--- a/src/library/PRUserial485.c
+++ b/src/library/PRUserial485.c
@@ -90,17 +90,17 @@ Date: May/2020
 *        | 0x5B - Single Sequence - Single Broadcast Function command
 *
 *
-* SHRAM[100] ~ SHRAM[6k-1] - Sending Data
+* SHRAM[100] ~ SHRAM[6143] - Sending Data
 *
 * prudata[100..103] = Tamanho do vetor de dados
 * prudata[104..] = vetor de dados
 *
 *
 *
-* SHRAM[6k] ~ SHRAM[12k-1] - Receiving Data
+* SHRAM[6144] ~ SHRAM[12k-1] - Receiving Data
 *
-* prudata[6k..6k+3] = Tamanho do vetor de dados
-* prudata[6k+4..] = vetor de dados
+* prudata[6144..6147] = Tamanho do vetor de dados
+* prudata[6148..] = vetor de dados
 */
 
 


### PR DESCRIPTION
The documentation in the comments stated that the receive-data offsets started at 6000, but `OFFSET_SHRAM_READ` is defined as `0x1800` (`6144` in decimal). This PR updates the comments to reflect the correct offset value. 

Alternatively, we could change the `#define OFFSET_SHRAM_READ` to match the comments (`6000`), if appropriate. 