### PR TITLE
update feedforward min/max range offsets

### DIFF
--- a/src/library/shram_mapping.h
+++ b/src/library/shram_mapping.h
@@ -105,7 +105,8 @@ Date: October/2024
 #define SHRAM_OFFSET_FF_ENABLED             14
 #define SHRAM_OFFSET_FF_N_TABLES            42
 #define SHRAM_OFFSET_FF_ID_TYPE             43
-#define SHRAM_OFFSET_FF_MAX_RANGE           44
+#define SHRAM_OFFSET_FF_MAX_RANGE           86
+#define SHRAM_OFFSET_FF_MIN_RANGE           90
 #define SHRAM_OFFSET_FF_POINTER             35
 #define SHRAM_OFFSET_FF_TABLE               37
 #define SHRAM_OFFSET_FF_TABLE_ABS_ADDR      38


### PR DESCRIPTION
Defines a feedforward minimum offset (SHRAM_OFFSET_MIN_RANGE) in the BeagleBone shared memory. It also updates the maximum offset (SHRAM_OFFSET_FF_MAX_RANGE). These changes repurpose previously unused offsets and were made to reflect a recent change in the FeedForward configuration that now also receives a minimum value.