### PR TITLE
Fix Slave-mode reception stalling under back-to-back messages

### DIFF
--- a/src/library/PRUserial485.c
+++ b/src/library/PRUserial485.c
@@ -616,8 +616,6 @@ void *monitorRecvBuffer(void *arg){
             // Aguarda dado salvo na SHRAM
             while(prudata[SHRAM_OFFSET_DATA_STATUS] != NEW_INCOMING_DATA){
             }
-            // ----- Sinaliza mensagem antiga
-            prudata[SHRAM_OFFSET_DATA_STATUS] = OLD_DATA;
 
             // Le ponteiro da PRU
             pru_recv_pointer = 0;
@@ -659,6 +657,10 @@ void *monitorRecvBuffer(void *arg){
                 }
             }
             pthread_mutex_unlock(&lock);
+
+            // ----- Sinaliza mensagem antiga (somente apos copiar os dados,
+            // para nao liberar o buffer da PRU antes da copia terminar)
+            prudata[SHRAM_OFFSET_DATA_STATUS] = OLD_DATA;
 
         }
     }

--- a/src/library/PRUserial485.p
+++ b/src/library/PRUserial485.p
@@ -754,7 +754,21 @@ WAIT_RECEIVED_SLAVE:
     QBEQ        SEND_DATA_SLAVE, I.b0, 0xff                     // 0x55 : Nada a enviar
 // -------------------------------------------
 
-    QBBS        WAIT_RECEIVED_SLAVE, IRQ                        // Data not received, loop continues
+    QBBC        GOT_FIRST_BYTE_SLAVE, IRQ                       // Interrupt fired, byte(s) arrived
+
+    // Watchdog: poll RxFIFO level directly instead of relying only on
+    // the empty->non-empty interrupt edge. If the FIFO never returns
+    // to empty between two back-to-back messages, that edge can be
+    // missed and this wait would otherwise stall forever even with
+    // bytes already sitting in the FIFO.
+    CS_DOWN
+    SEND_SPI    0x12, 8
+    RECEIVE_SPI 8
+    CS_UP
+    LSR         BUFFER_SPI_IN, BUFFER_SPI_IN, 4
+    QBEQ        WAIT_RECEIVED_SLAVE, BUFFER_SPI_IN, 0           // Still empty, keep waiting
+
+GOT_FIRST_BYTE_SLAVE:
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 


### PR DESCRIPTION
### Context

While building a passive RS-485 sniffer on top of Slave mode (goal: capture every packet on a Power Supply bus with no silent loss), reception reliably corrupted or permanently stalled once real two-way traffic was involved, specifically a command immediately followed by its reply from a different device. This never showed up in a synthetic single-writer test at equal or higher message rates, only with a genuine second, independently-timed transmitter on the bus.

Two separate bugs were found and fixed.

### Bug 1. host-side race on the receive buffer 

`monitorRecvBuffer()` in `PRUserial485.c` marked the shared-RAM buffer as
  consumed (`OLD_DATA`) before copying the received bytes out of it:

```c
while(prudata[SHRAM_OFFSET_DATA_STATUS] != NEW_INCOMING_DATA) {}
prudata[SHRAM_OFFSET_DATA_STATUS] = OLD_DATA;   // told the PRU "go ahead" too early
// ... pointer read, size calc, and the actual byte copy all happen after this
```

PRU-side Slave mode does not gate starting a new reception on this flag, so a message arriving quickly after the previous one could begin overwriting shared RAM while the host was still mid-copy, corrupting or truncating the message being read.
                                      
**Fix**: move the OLD_DATA signal to after the copy loop completes, so the PRU is never told the buffer is free before the host has actually finished reading it.

### Bug 2. PRU can permanently stall waiting for a missed interrupt edge

WAIT_RECEIVED_SLAVE only progresses on the MAX3107's RxEmtyInt (ISR bit 6) interrupt. Per the MAX3107 datasheet, with RxEmtyInv set high (Mode2 = 0x88, as configured in RECEIVE_DATA_SLAVE):


> If RxEmtyInv is set high, the ISR[6] interrupt is generated when data is
> put into the empty receive FIFO.

This is an edge condition, not a level. If the RX FIFO is still non-empty (carrying an already-arrived, not-yet-consumed byte) at the moment the next message's first byte lands, the "put into an empty FIFO" condition is never satisfied, ISR[6] never sets, IRQ never asserts, and the PRU busy-waits in WAIT_RECEIVED_SLAVE forever, even with real unread data sitting in the FIFO. This matches exactly the scenario that triggered it: a reply arriving before the PRU finished processing the preceding message and re-armed the interrupt for the next one. See attached flowchart....

<img width="952" height="559" alt="stuck-pruserial485-slavemode" src="https://github.com/user-attachments/assets/7304bcef-def8-4b28-b7cc-32ead8832cfb" />

**Fix**: when the interrupt hasn't fired, poll the RxFIFO level directly via SPI (0x12, the same technique already used in RXLEVEL_AND_TIMEOUT_SLAVE) as a fallback ground-truth check, instead of relying solely on the edge notification. The common/working case (interrupt fires normally) is unchanged, this only adds cost on the rare iteration where the edge was missed.

### Testing

1. Verified full hardware/software chain end-to-end and live traffic capture before investigating the bug.
2. Reproduced the issue on a real deployment test setup: a CLP-emulator unit driving a FeedForward controller, which computes and forwards setpoints to a real Power Supply over the RS-485 bus; a third BeagleBone in Slave mode passively sniffed the FF <---> PS traffic.
3. Confirmed the stall was inside the PRU firmware itself (not host-side buffering) by reading the PRU's on-chip receive pointer directly via shared RAM offset 0x1800 during a stall. It was completely frozen (non-incrementing) while the ARM side also reported no data.
4. Isolated the trigger to the two-transmitter reply/turnaround scenario: disconnecting the PS (FF still transmitting on schedule, nothing ever replies) ran cleanly with zero stalls; reconnecting the PS reliably reproduced stalls/corruption again.
6. After Bug 2's fix was added: ran continuously overnight with real FF + PS traffic. Zero stalls observed. 


